### PR TITLE
New Project Pupil Video Backend added

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Want to add your project, fork, plugin, or script to this list? Fork this repo a
 Want to add your demo video to this list? Make an [issue](https://github.com/pupil-labs/pupil-community/issues) with the Youtube link and the maintainers will add the video to [this Youtube playlist](https://www.youtube.com/watch?v=X_BalnBOcpk&list=PLi20Yl1k_57pr6zl9D6JHSrOWyLXxsTQN).
 
 ## Projects & Forks
+- [Pupil Video Backend](https://github.com/Lifestohack/pupil-video-backend) - Streams Video from another computer through the network to your computer where pupil capture software is running.
 - [Pupil Labs Motion Capture Trigger](https://github.com/N-M-T/Pupil-Labs-Mocap-Trigger) - Use a low-cost Arduino microcontroller to synchronise motion capture systems (e.g. Vicon/Qualisys) with the Pupil Core Mobile eye tracker.
 - [Plugin to Perceive the Object in Focus](https://github.com/jesseweisberg/pupil) - Real-time object-detection plugin that integrates eye-tracking (fixation data) to identify which object the user is currently fixated upon. An example of its potential is shown in controlling grasps of a robotic prosthetic hand. Part of the [Therabotics Project](https://www.jesseweisberg.com/therabotics/)
 - [PolyMouse](https://github.com/trishume/PolyMouse) - PolyMouse is a fusion of gaze tracking and head tracking to achieve hands-free pointing. It does this by using eye gaze to quickly determine an imprecise area of interest and then uses small head movements to refine the position of the cursor onto a small target.


### PR DESCRIPTION
This program helps you to stream the video from another computer or Raspberry pi to your computer where pupil capture software is running. No configuration is needed on the computer where pupil capture software is running. Just Run this program on remote computer with webcam. Make sure pupil capture software is already running before running this program.